### PR TITLE
Remove Errors For `.nodes`

### DIFF
--- a/instrument-repl/src/lib.rs
+++ b/instrument-repl/src/lib.rs
@@ -1,4 +1,9 @@
-#![feature(lint_reasons, rustdoc_missing_doc_code_examples, stmt_expr_attributes)]
+#![feature(
+    lint_reasons,
+    rustdoc_missing_doc_code_examples,
+    stmt_expr_attributes,
+    io_error_more
+)]
 #![deny(
     clippy::undocumented_unsafe_blocks,
     clippy::pedantic,

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -552,15 +552,6 @@ impl Repl {
                     };
                     let json_file = PathBuf::from(file.clone());
 
-                    if !json_file.is_file() {
-                        return Ok(Request::Usage(
-                            InstrumentReplError::Other(format!(
-                                "unable to find file \"{}\"",
-                                json_file.to_string_lossy()
-                            ))
-                            .to_string(),
-                        ));
-                    }
                     Request::TspLinkNodes { json_file }
                 }
             },

--- a/instrument-repl/src/resources/TspLinkNodeDetails.tsp
+++ b/instrument-repl/src/resources/TspLinkNodeDetails.tsp
@@ -15,9 +15,9 @@ end
 
 
 if tsplink.initialize == nil then
-  tsplink.reset()
+  tsplink.reset(1)
 else
-  tsplink.initialize()
+  tsplink.initialize(0)
 end
 
 if (tsplink.state == "online") then

--- a/instrument-repl/src/resources/TspLinkNodeDetails.tsp
+++ b/instrument-repl/src/resources/TspLinkNodeDetails.tsp
@@ -17,7 +17,7 @@ end
 if tsplink.initialize == nil then
   tsplink.reset(1)
 else
-  tsplink.initialize(0)
+  tsplink.initialize(1)
 end
 
 if (tsplink.state == "online") then

--- a/kic-discover/src/main.rs
+++ b/kic-discover/src/main.rs
@@ -135,8 +135,7 @@ async fn init_rpc() -> anyhow::Result<ServerHandle> {
 
         if let Ok(db) = DISC_INSTRUMENTS.lock() {
             db.iter()
-                .enumerate()
-                .for_each(|(_i, item)| new_out_str = format!("{new_out_str}{item}\n"));
+                .for_each(|item| new_out_str = format!("{new_out_str}{item}\n"));
         };
 
         #[cfg(debug_assertions)]


### PR DESCRIPTION
When calling `.nodes <file>` there were a few unnecessary error cases:
1. If there were no TSP-Link nodes to initialize, an error would be added to the errorqueue
    - This was fixed by using `tsplink.reset(1)` and `tsplink.initialize(0)` instead of the no-parameter overloads
2. If the given file didn't exist, an error was thrown even though we can create it.
    - This was fixed by removing the check for file existence. 

This PR also includes an incidental fix for a clippy warning. We were calling `enumerate` unnecessarily.