### PR TITLE
Update CI to Handle No `dev` Branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -220,15 +220,31 @@ jobs:
         if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
         run: |
           git config --global --add safe.directory "$PWD"
+          apt-get install -yqq jq
           COMMIT="${{github.sha}}"
-          V="${{github.head_ref}}"
-          V="${V#release/v}"
-
-          if ${{! github.event.pull_request.merged}}; then
-            V="${V}-$(git tag --list v${V}* | wc -l)"
+          if ${{contains(github.head_ref, 'release')}}; then
+            V="${{github.head_ref}}"
+            V="${V#release/}"
+          else
+            V="$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version')"
+            V=v${V//\"/} #remove '"'s
           fi
 
-          CL=${V}
+          # Check to see if the version tag already exists
+          # If it does, print a message and exit with an error code
+          if [ $(git tag --list "$V") ]; then
+            echo "Version tag already exists. Did you bump the version number?"
+            exit 1
+          fi
+
+          # Create an RC release if
+          # 1) This PR is a release branch that hasn't been merged to main.
+          # 2) This is a feature branch being merged into the main branch.
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release'))}}; then
+            V="${V}-$(git tag --list ${V}* | wc -l)"
+          fi
+
+          CL=${V#v}
           CL=${CL%-*}
 
           echo "version=${V}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -217,7 +217,7 @@ jobs:
           path: target/
       - name: Get Tagged Version
         id: lasttag
-        if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
+        if: ${{ endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/') || github.event.pull_request.merged) }}
         run: |
           git config --global --add safe.directory "$PWD"
           apt-get install -yqq jq
@@ -240,7 +240,7 @@ jobs:
           # Create an RC release if
           # 1) This PR is a release branch that hasn't been merged to main.
           # 2) This is a feature branch being merged into the main branch.
-          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release'))}}; then
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release/')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release/'))}}; then
             V="${V}-$(git tag --list ${V}* | wc -l)"
           fi
 
@@ -268,7 +268,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
+    if: ${{ endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/') || github.event.pull_request.merged) }}
     needs:
       - build
       - lint
@@ -320,7 +320,7 @@ jobs:
       - code_coverage
       - package
       - sbom
-    if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
+    if: ${{ endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/') || github.event.pull_request.merged) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -330,11 +330,28 @@ jobs:
       - name: Get Tagged Version
         id: lasttag
         run: |
+          git config --global --add safe.directory "$PWD"
+          apt-get install -yqq jq
           COMMIT="${{github.sha}}"
-          V="${{github.head_ref}}"
-          V="${V#release/}"
+          if ${{contains(github.head_ref, 'release/')}}; then
+            V="${{github.head_ref}}"
+            V="${V#release/}"
+          else
+            V="$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version')"
+            V=v${V//\"/} #remove '"'s
+          fi
 
-          if ${{! github.event.pull_request.merged}}; then
+          # Check to see if the version tag already exists
+          # If it does, print a message and exit with an error code
+          if [ $(git tag --list "$V") ]; then
+            echo "Version tag already exists. Did you bump the version number?"
+            exit 1
+          fi
+
+          # Create an RC release if
+          # 1) This PR is a release branch that hasn't been merged to main.
+          # 2) This is a feature branch being merged into the main branch.
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release/')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release/'))}}; then
             V="${V}-$(git tag --list ${V}* | wc -l)"
           fi
 
@@ -344,6 +361,7 @@ jobs:
           echo "version=${V}" >> $GITHUB_OUTPUT
           echo "cl_version=${CL}" >> $GITHUB_OUTPUT
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
+
       - run: 'git tag --list ${V}*'
       - name: Get Artifacts
         uses: actions/download-artifact@v3
@@ -378,7 +396,7 @@ jobs:
 
             ${{steps.changelog.outputs.description}}
 
-          prerelease: ${{! github.event.pull_request.merged}}
+          prerelease: ${{(! github.event.pull_request.merged) || (github.event.pull_request.merged && ! contains(github.head_ref, 'release/'))}}
           commit: ${{steps.lasttag.outputs.commit}}
           makeLatest: true
           tag: ${{steps.lasttag.outputs.version}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -220,7 +220,7 @@ jobs:
         if: ${{ endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/') || github.event.pull_request.merged) }}
         run: |
           git config --global --add safe.directory "$PWD"
-          apt-get install -yqq jq
+          apt-get update && apt-get install -yqq jq
           COMMIT="${{github.sha}}"
           if ${{contains(github.head_ref, 'release')}}; then
             V="${{github.head_ref}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Fixed -- for any bug fixes.
     Security -- in case of vulnerabilities.
 -->
+## [0.15.1]
+
 ## [0.15.0]
 
 ### Fixed
@@ -74,7 +76,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.15.1
 [0.15.0]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.15.0
 [0.14.1]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.14.1
 [0.13.2]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.13.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 -->
 ## [0.15.1]
 
+### Changed
+- No changes yet
+
 ## [0.15.0]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "instrument-repl"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "kic"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "kic-discover"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-cli"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tektronix/kic-cli",
-            "version": "0.15.0",
+            "version": "0.15.1",
             "bin": {
                 "linux-kic": "bin/kic",
                 "linux-kic-discover": "bin/kic-discover",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "main": "index.js",
     "bin": {
         "windows-kic": "./bin/kic.exe",


### PR DESCRIPTION
To simplify the release workflow, the team has decided to remove the `dev` branch. This change requires a few changes to the CI system for all projects.

1. For every feature-branch pull request the is merged to `main`, create an appropriately versioned RC release (a tag, a GitHub release, plus any packaging) with the version indicated by the project's manifest file followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
2. If the branch merging into `main` is a release branch, create an RC for every push to that branch with the version indicated by the release branch name followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
3. If a pull request is merged to `main` from a release branch, create a full release with the version number indicated in the release branch name.