### PR TITLE
Fix Showing Prompt Immediately After Loading Script

### DIFF
--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -230,7 +230,7 @@ impl Repl {
                                     );
                                 }
                             }
-                            prompt = true;
+                            prompt = false;
                         }
                         Request::TspLinkNodes { json_file } => {
                             self.set_lang_config_path(json_file.to_string_lossy().to_string());


### PR DESCRIPTION
This was a simple fix: after we load a script we were setting a boolean to immediately print a prompt to the user. Simple fix was to set this to false. 