### PR TITLE
Upgrade wording consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [0.16.2]
+
+### Changed
+- Renamed update to upgrade for firmware upgrade in CLI arguments (TSP-741)
+
 ## [0.16.1]
 
 ### Changed
@@ -104,7 +109,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.16.1
 [0.16.1]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.16.1
 [0.16.0]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.16.0
 [0.15.3]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.15.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "instrument-repl"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "kic"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "kic-discover"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-cli"

--- a/kic/src/main.rs
+++ b/kic/src/main.rs
@@ -134,7 +134,7 @@ fn cmds() -> Command {
             ])
         })
         .subcommand({
-            let cmd = Command::new("update")
+            let cmd = Command::new("upgrade")
                 .about("Upgrade the firmware of an instrument or module.");
 
             add_connection_subcommands(cmd, [
@@ -212,8 +212,8 @@ fn main() -> anyhow::Result<()> {
         Some(("connect", sub_matches)) => {
             return connect(sub_matches);
         }
-        Some(("update", sub_matches)) => {
-            return update(sub_matches);
+        Some(("upgrade", sub_matches)) => {
+            return upgrade(sub_matches);
         }
         Some(("terminate", sub_matches)) => {
             return terminate(sub_matches);
@@ -362,7 +362,7 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
     Ok(repl.start()?)
 }
 
-fn update(args: &ArgMatches) -> anyhow::Result<()> {
+fn upgrade(args: &ArgMatches) -> anyhow::Result<()> {
     eprintln!("\nKeithley TSP Shell\n");
     let lan = ConnectionType::try_from_arg_matches(args)?;
     let Some((_, args)) = args.subcommand() else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tektronix/kic-cli",
-            "version": "0.16.1",
+            "version": "0.16.2",
             "bin": {
                 "linux-kic": "bin/kic",
                 "linux-kic-discover": "bin/kic-discover",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "main": "index.js",
     "bin": {
         "windows-kic": "./bin/kic.exe",


### PR DESCRIPTION
The CLI arguments were still expecting `update` instead of `upgrade`. Change this for consistency.
