### PR TITLE
Add option for log-socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [0.17.0]
 
+### Added
+- Added logging infrastructure over socket, in files, and to stderr in `kic` and `kic-discover`.
+
 ### Fixed
-- Fixed an indexing issue for uploading modules (TSP-761) *Open Source Contribution: c3charvat, amcooper181*
+- Fixed an indexing issue for upgrading module firmware (TSP-761) *Open Source Contribution: c3charvat, amcooper181*
 
 ## [0.16.2]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "instrument-repl"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "kic"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "kic-discover"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2556,17 +2556,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "nu-ansi-term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1.0.114"
 thiserror = "1.0.58"
 tmc = { git = "https://github.com/esarver/rusb-usbtmc" }
 tracing = { version = "0.1.40", features = ["async-await"] }
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["json"] }
 tsp-toolkit-kic-lib = { git = "https://github.com/tektronix/tsp-toolkit-kic-lib.git", tag = "v0.16.1" }
 
 [workspace.lints.rust]

--- a/kic-discover/src/main.rs
+++ b/kic-discover/src/main.rs
@@ -103,7 +103,7 @@ fn start_logger(
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -144,7 +144,7 @@ fn start_logger(
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -173,7 +173,7 @@ fn start_logger(
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -196,7 +196,7 @@ fn start_logger(
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default().with(LevelFilter::TRACE).with(sock);
 

--- a/kic/src/main.rs
+++ b/kic/src/main.rs
@@ -257,7 +257,7 @@ fn main() -> anyhow::Result<()> {
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -298,7 +298,7 @@ fn main() -> anyhow::Result<()> {
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -327,7 +327,7 @@ fn main() -> anyhow::Result<()> {
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default()
                 .with(LevelFilter::TRACE)
@@ -350,7 +350,7 @@ fn main() -> anyhow::Result<()> {
             let sock = tracing_subscriber::fmt::layer()
                 .with_writer(Mutex::new(sock))
                 .fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())
-                .with_ansi(false);
+                .json();
 
             let logger = Registry::default().with(LevelFilter::TRACE).with(sock);
 


### PR DESCRIPTION
This is to enable logging to the output pane in VSCode. Other users can also use this feature if they want to log out to a specific server.