### PR TITLE
Fix ReadSTB Timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - .script , .upgrade and .exit commands descriptions updated
 - When using VISA, only call ReadSTB after writing commands to the instrument
   (or every 3 seconds for a heartbeat)
+- Pause when an error occurs so users can see the errors
 
 ## [0.18.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - .script , .upgrade and .exit commands descriptions updated
+- When using VISA, only call ReadSTB after writing commands to the instrument
+  (or every 3 seconds for a heartbeat)
 
 ## [0.18.2]
 

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -15,7 +15,8 @@ use std::{
     fs::{self, File},
     io::{self, Read, Write},
     path::PathBuf,
-    sync::mpsc::{channel, SendError, Sender, TryRecvError},
+    process::exit,
+    sync::mpsc::{channel, Sender, TryRecvError},
     thread::JoinHandle,
     time::{Duration, Instant},
 };
@@ -724,9 +725,9 @@ impl Repl {
                         let mut input = String::new();
                         let _ = std::io::stdin().read_line(&mut input)?;
                         let req = Self::parse_user_commands(&input)?;
-                        match out.send(req.clone()) {
-                            Ok(()) => {}
-                            Err(SendError(_)) => break 'input_loop,
+                        if out.send(req.clone()).is_err() {
+                            error!("User input thread could not send to Receiver. Closing!");
+                            exit(1);
                         }
                         // This `if` statement seeks to fix the NOTE above about not exiting.
                         // It feels a little awkward, but should be effective.

--- a/kic-discover-visa/src/visa.rs
+++ b/kic-discover-visa/src/visa.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, ffi::CString, time::Duration};
 
-use async_std::fs::write;
 use serde::{Deserialize, Serialize};
 use tracing::{error, trace};
 use tsp_toolkit_kic_lib::{

--- a/kic-visa/src/main.rs
+++ b/kic-visa/src/main.rs
@@ -619,6 +619,7 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
     info!("Starting instrument REPL");
     if let Err(e) = repl.start() {
         error!("Error in REPL: {e}");
+        eprintln!("{}", format!("{e}\nClosing...").red());
     }
 
     Ok(())

--- a/kic-visa/src/main.rs
+++ b/kic-visa/src/main.rs
@@ -576,6 +576,15 @@ fn get_instrument_access(inst: &mut Box<dyn Instrument>) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn pause_exit_on_error() {
+    eprintln!(
+        "\n\n{}",
+        "An error occured. Press Enter to close this program.".yellow()
+    );
+    let mut buf = String::new();
+    let _ = std::io::stdin().read_line(&mut buf);
+}
+
 #[instrument(skip(args))]
 fn connect(args: &ArgMatches) -> anyhow::Result<()> {
     info!("Connecting to instrument");
@@ -588,6 +597,11 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
         Ok(c) => c,
         Err(e) => {
             error!("Unable to parse connection information: {e}");
+            eprintln!(
+                "{}",
+                format!("\nUnable to parse connection information: {e}\n\nUnrecoverable error. Closing.").red()
+            );
+            pause_exit_on_error();
             return Err(e);
         }
     };
@@ -595,12 +609,25 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
         Ok(i) => i,
         Err(e) => {
             error!("Error connecting to async instrument: {e}");
+            eprintln!(
+                "{}",
+                format!(
+                    "\nError connecting to async instrument: {e}\n\nUnrecoverable error. Closing."
+                )
+                .red()
+            );
+            pause_exit_on_error();
             return Err(e);
         }
     };
 
     if let Err(e) = get_instrument_access(&mut instrument) {
         error!("Error setting up instrument: {e}");
+        eprintln!(
+            "{}",
+            format!("\nError setting up instrument: {e}\n\nUnrecoverable error. Closing.").red()
+        );
+        pause_exit_on_error();
         return Err(e);
     }
 
@@ -608,6 +635,12 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
         Ok(i) => i,
         Err(e) => {
             error!("Error getting instrument info: {e}");
+            eprintln!(
+                "{}",
+                format!("\nError getting instrument info: {e}\n\nUnrecoverable error. Closing.")
+                    .red()
+            );
+            pause_exit_on_error();
             return Err(e.into());
         }
     };
@@ -619,7 +652,12 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
     info!("Starting instrument REPL");
     if let Err(e) = repl.start() {
         error!("Error in REPL: {e}");
-        eprintln!("{}", format!("{e}\nClosing...").red());
+        eprintln!(
+            "{}",
+            format!("\n{e}\n\nClosing instrument connection...").red()
+        );
+        drop(repl);
+        pause_exit_on_error();
     }
 
     Ok(())

--- a/kic/src/main.rs
+++ b/kic/src/main.rs
@@ -615,6 +615,7 @@ fn connect(args: &ArgMatches) -> anyhow::Result<()> {
     info!("Starting instrument REPL");
     if let Err(e) = repl.start() {
         error!("Error in REPL: {e}");
+        eprintln!("{}", format!("{e}\nClosing...").red());
     }
 
     Ok(())


### PR DESCRIPTION
This fixes the issue of calling `ReadSTB()` every 2ms when connected to an instrument over a VISA connection. 

Now we only call `ReadSTB()` after the user sends something to the instrument (such as a TSP command, a script, or an upgrade) OR as a heartbeat every 3 seconds in the case an instrument stops responding.