### PR TITLE
Release Archive per Target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -217,6 +217,40 @@ jobs:
             target/${{matrix.triple}}/release/kic*
             !target/${{matrix.triple}}/**/*.d
             !target/${{matrix.triple}}/**/*.rlib
+            !target/${{matrix.triple}}/**/*.pdb
+
+  package-release:
+    name: Package for Release
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            triple: x86_64-unknown-linux-gnu
+            vscode-platform: linux-x64
+          - runner: windows-latest
+            triple: x86_64-pc-windows-msvc
+            vscode-platform: win32-x64
+          - runner: macos-latest
+            triple: aarch64-apple-darwin
+            vscode-platform: darwin-arm64
+    runs-on: ubuntu-latest
+    needs:
+      build
+    steps:
+      - name: Get Executable Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{matrix.vscode-platform}}-executable
+          path: executables/
+      - name: Create Executable Archive
+        run: |
+          cd executables/
+          tar czf ../kic-${{matrix.vscode-platform}}.tar.gz *
+      - name: Upload Archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.vscode-platform}}-archive
+          path: kic-${{matrix.vscode-platform}}.tar.gz
 
   package:
     name: Package
@@ -378,6 +412,7 @@ jobs:
       - style
       - test
       - code_coverage
+      - package-release
       - package
       - sbom
     if: ${{ endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/') || github.event.pull_request.merged) }}
@@ -429,7 +464,7 @@ jobs:
       - name: Get Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "*-executable"
+          pattern: "*-archive"
           path: target
           merge-multiple: true
       - name: Get SBOM

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ on:
       - closed
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   style:
@@ -104,7 +104,7 @@ jobs:
         with:
           repository: tektronix/libvisa-stub
           latest: true
-          fileName: '*'
+          fileName: "*"
       - name: Prebuild
         run: |
           git config --global credential.helper store
@@ -197,7 +197,7 @@ jobs:
         with:
           repository: tektronix/libvisa-stub
           latest: true
-          fileName: '*'
+          fileName: "*"
       - name: Build LAN-only
         run: |
           git config --global credential.helper store
@@ -235,7 +235,7 @@ jobs:
             vscode-platform: darwin-arm64
     runs-on: ubuntu-latest
     needs:
-      build
+      - build
     steps:
       - name: Get Executable Artifacts
         uses: actions/download-artifact@v4
@@ -381,9 +381,9 @@ jobs:
         run: npm --version
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@tektronix'
+          node-version: "20.x"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@tektronix"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get Artifacts
@@ -460,7 +460,7 @@ jobs:
           echo "cl_version=${CL}" >> $GITHUB_OUTPUT
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
 
-      - run: 'git tag --list ${V}*'
+      - run: "git tag --list ${V}*"
       - name: Get Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -499,4 +499,3 @@ jobs:
           commit: ${{steps.lasttag.outputs.commit}}
           makeLatest: true
           tag: ${{steps.lasttag.outputs.version}}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added new `--dump-output` arg to `connect` subcommand to support printing the
   `dump` subcommand details to the terminal
 
+### Fixed
+
+- Fixed CI issue where macOS artifacts would overwrite linux artifacts
+
 ## [0.18.4]
 
 ### Fixed


### PR DESCRIPTION
- Each target now gets it's own archive (tar.gz) instead of being a giant pile of executables.
