### PR TITLE
Get TCPIP VISA Instrument Info from LXI ID Page Instead of `*IDN?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Fixed CI issue where macOS artifacts would overwrite linux artifacts
+- VISA discovery now properly cleans up instrument after getting info
 
 ## [0.18.4]
 

--- a/kic-discover-visa/src/ethernet/mod.rs
+++ b/kic-discover-visa/src/ethernet/mod.rs
@@ -13,10 +13,11 @@ use crate::{insert_disc_device, model_check, IoType};
 
 pub const COMM_PORT: u16 = 5025;
 pub const DST_PORT: u16 = 5030;
-pub const SERVICE_NAMES: [&str; 3] = [
+pub const SERVICE_NAMES: [&str; 4] = [
     "_scpi-raw._tcp.local",
     "_lxi._tcp.local",
     "_vxi-11._tcp.local",
+    "_hislip._tcp.local",
     //"_scpi-telnet._tcp.local",
 ];
 

--- a/kic-discover/src/ethernet/mod.rs
+++ b/kic-discover/src/ethernet/mod.rs
@@ -13,10 +13,11 @@ use crate::{insert_disc_device, model_check, IoType};
 
 pub const COMM_PORT: u16 = 5025;
 pub const DST_PORT: u16 = 5030;
-pub const SERVICE_NAMES: [&str; 3] = [
+pub const SERVICE_NAMES: [&str; 4] = [
     "_scpi-raw._tcp.local",
     "_lxi._tcp.local",
     "_vxi-11._tcp.local",
+    "_hislip._tcp.local",
     //"_scpi-telnet._tcp.local",
 ];
 


### PR DESCRIPTION
This is a less disruptive way to get the Instrument information since it gets this information from the webpage instead of from the command processor on the instrument.

Testing: This has been tested using NI VISA and a Keithley Model 2461