### PR TITLE
Fixing flash issue for tti and 2600 model

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,8 @@
             "name": "(Windows) kic Launch",
             "type": "lldb",
             "request": "launch",
-            "program": "${workspaceFolder}/target/debug/kic",
-            "args": ["connect","lan", "134.63.78.86"],
+            "program": "${workspaceFolder}/target/debug/kic-visa",
+            "args": ["connect", "10.233.237.120"],
             "cwd": "${workspaceRoot}",
 
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Fixed -- for any bug fixes.
     Security -- in case of vulnerabilities.
 -->
+
+## [0.20.1]
+
+### Fixed
+- Getting error after firmware file transferred successfully
+- Firmware upgrade for TTI and 2600 models getting stuck over slow connection speeds 
+
 ## [0.20.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "instrument-repl"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "kic"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "kic-discover"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "kic-discover-visa"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "kic-lib"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "kic-visa"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Tektronix, Inc."]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-cli"

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -345,8 +345,8 @@ impl Repl {
                                         )?;
                                         // Upgrading Mainframe
                                         Self::println_flush(&"Close the terminal and reconnect after the instrument has restarted.".bright_yellow())?;
+                                        break 'user_loop;
                                     }
-                                    break 'user_loop;
                                 }
                                 Err(InstrumentError::FwUpgradeFailure(msg)) => {
                                     error!("{msg}");

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -344,8 +344,9 @@ impl Repl {
                                             &"Firmware file download complete.".bright_yellow(),
                                         )?;
                                         // Upgrading Mainframe
-                                        Self::println_flush(&"Close the terminal (.exit) and reconnect after the instrument has restarted.".bright_yellow())?;
+                                        Self::println_flush(&"Close the terminal and reconnect after the instrument has restarted.".bright_yellow())?;
                                     }
+                                    break 'user_loop;
                                 }
                                 Err(InstrumentError::FwUpgradeFailure(msg)) => {
                                     error!("{msg}");

--- a/kic-lib/src/model/ki2600.rs
+++ b/kic-lib/src/model/ki2600.rs
@@ -137,6 +137,7 @@ impl Script for Instrument {}
 
 impl Flash for Instrument {
     fn flash_firmware(&mut self, image: &[u8], _: Option<u16>) -> crate::error::Result<()> {
+        let _ = self.set_nonblocking(false);
         #[allow(irrefutable_let_patterns)] //This is marked as irrefutable when building without
         //visa
         let spinner = if let Protocol::Raw(_) = self.protocol {
@@ -167,6 +168,7 @@ impl Flash for Instrument {
             eprintln!("Firmware file transferred successfully. Upgrade running on instrument.");
         }
         Ok(())
+        
     }
 }
 

--- a/kic-lib/src/model/ki2600.rs
+++ b/kic-lib/src/model/ki2600.rs
@@ -160,6 +160,9 @@ impl Flash for Instrument {
         self.write_all(b"flash\n")?;
         self.write_all(image.fill_buf().unwrap())?;
         self.write_all(b"endflash\n")?;
+
+        // Only sleep in non-test builds
+        #[cfg(not(test))]
         std::thread::sleep(Duration::from_secs(180));
         if let Some(pb) = spinner {
             pb.finish_with_message(
@@ -1074,6 +1077,12 @@ mod unit {
         let mut seq = Sequence::new();
 
         interface
+            .expect_set_nonblocking()
+            .times(1)
+            .withf(|enable| !*enable)
+            .returning(|_| Ok(()));
+
+        interface
             .expect_write()
             .times(1)
             .in_sequence(&mut seq)
@@ -1105,6 +1114,13 @@ mod unit {
             .in_sequence(&mut seq)
             .withf(|buf: &[u8]| buf == b"endflash\n")
             .returning(|buf: &[u8]| Ok(buf.len()));
+
+        interface
+            .expect_set_nonblocking()
+            .times(1)
+            .withf(|enable| *enable)
+            .returning(|_| Ok(()));
+
         interface
             .expect_write()
             .times(..)

--- a/kic-lib/src/model/ki2600.rs
+++ b/kic-lib/src/model/ki2600.rs
@@ -160,6 +160,7 @@ impl Flash for Instrument {
         self.write_all(b"flash\n")?;
         self.write_all(image.fill_buf().unwrap())?;
         self.write_all(b"endflash\n")?;
+        std::thread::sleep(Duration::from_secs(180));
         if let Some(pb) = spinner {
             pb.finish_with_message(
                 "Firmware file transferred successfully. Upgrade running on instrument.",
@@ -167,8 +168,8 @@ impl Flash for Instrument {
         } else {
             eprintln!("Firmware file transferred successfully. Upgrade running on instrument.");
         }
+        let _ = self.set_nonblocking(true);
         Ok(())
-        
     }
 }
 

--- a/kic-lib/src/model/ki3700.rs
+++ b/kic-lib/src/model/ki3700.rs
@@ -170,6 +170,9 @@ impl Flash for Instrument {
 
         std::thread::sleep(Duration::from_millis(10)); //The position and duration of this delay is intentional
         self.write_all(b"endflash\n")?;
+
+        // Only sleep in non-test builds
+        #[cfg(not(test))]
         std::thread::sleep(Duration::from_secs(180));
 
         if let Some(pb) = spinner {
@@ -1077,6 +1080,12 @@ mod unit {
         interface.expect_flush().times(..).returning(|| Ok(()));
 
         interface
+            .expect_set_nonblocking()
+            .times(1)
+            .withf(|enable| !*enable)
+            .returning(|_| Ok(()));
+
+        interface
             .expect_write()
             .times(1)
             .in_sequence(&mut seq)
@@ -1108,6 +1117,13 @@ mod unit {
             .in_sequence(&mut seq)
             .withf(|buf: &[u8]| buf == b"endflash\n")
             .returning(|buf: &[u8]| Ok(buf.len()));
+
+        interface
+            .expect_set_nonblocking()
+            .times(1)
+            .withf(|enable| *enable)
+            .returning(|_| Ok(()));
+
         interface
             .expect_write()
             .times(..)

--- a/kic-lib/src/model/ki3700.rs
+++ b/kic-lib/src/model/ki3700.rs
@@ -146,6 +146,7 @@ impl Flash for Instrument {
 
         #[allow(irrefutable_let_patterns)] //This is marked as irrefutable when building without
         //visa
+        let _ = self.set_nonblocking(false);
         let spinner = if let Protocol::Raw(_) = self.protocol {
             let pb = ProgressBar::new(1);
             #[allow(clippy::literal_string_with_formatting_args)]

--- a/kic-lib/src/model/ki3700.rs
+++ b/kic-lib/src/model/ki3700.rs
@@ -170,6 +170,7 @@ impl Flash for Instrument {
 
         std::thread::sleep(Duration::from_millis(10)); //The position and duration of this delay is intentional
         self.write_all(b"endflash\n")?;
+        std::thread::sleep(Duration::from_secs(180));
 
         if let Some(pb) = spinner {
             pb.finish_with_message(
@@ -178,6 +179,7 @@ impl Flash for Instrument {
         } else {
             eprintln!("Firmware file transferred successfully. Upgrade running on instrument.");
         }
+        let _ = self.set_nonblocking(true);
         Ok(())
     }
 }

--- a/kic-lib/src/model/tti.rs
+++ b/kic-lib/src/model/tti.rs
@@ -205,6 +205,8 @@ impl Flash for Instrument {
 
         self.write_all(b"endflash\n")?;
 
+        std::thread::sleep(Duration::from_secs(180));
+
         if let Some(pb) = spinner {
             pb.finish_with_message(
                 "Firmware file transferred successfully. Upgrade running on instrument.",
@@ -212,6 +214,7 @@ impl Flash for Instrument {
         } else {
             eprintln!("Firmware file transferred successfully. Upgrade running on instrument.");
         }
+        let _ = self.set_nonblocking(true);
         Ok(())
     }
 }

--- a/kic-lib/src/model/tti.rs
+++ b/kic-lib/src/model/tti.rs
@@ -179,6 +179,7 @@ impl Flash for Instrument {
     fn flash_firmware(&mut self, image: &[u8], _: Option<u16>) -> crate::error::Result<()> {
         #[allow(irrefutable_let_patterns)] //This is marked as irrefutable when building without
         //visa
+        let _ = self.set_nonblocking(false);
         let spinner = if let Protocol::Raw(_) = self.protocol {
             let pb = ProgressBar::new(1);
             #[allow(clippy::literal_string_with_formatting_args)]

--- a/kic-lib/src/model/versatest.rs
+++ b/kic-lib/src/model/versatest.rs
@@ -221,7 +221,6 @@ impl Flash for Instrument {
 
         #[allow(irrefutable_let_patterns)] //This is marked as irrefutable when building without
         //visa
-        let _ = self.set_nonblocking(false);
         let mut spinner = if let Protocol::Raw(_) = self.protocol {
             let pb = ProgressBar::new(1);
             #[allow(clippy::literal_string_with_formatting_args)]

--- a/kic-lib/src/model/versatest.rs
+++ b/kic-lib/src/model/versatest.rs
@@ -221,6 +221,7 @@ impl Flash for Instrument {
 
         #[allow(irrefutable_let_patterns)] //This is marked as irrefutable when building without
         //visa
+        let _ = self.set_nonblocking(false);
         let mut spinner = if let Protocol::Raw(_) = self.protocol {
             let pb = ProgressBar::new(1);
             #[allow(clippy::literal_string_with_formatting_args)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tektronix/kic-cli",
-            "version": "0.20.0",
+            "version": "0.20.1",
             "bin": {
                 "linux-kic": "bin/kic",
                 "linux-kic-discover": "bin/kic-discover",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tektronix/kic-cli",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "main": "index.js",
     "bin": {
         "windows-kic": "./bin/kic.exe",


### PR DESCRIPTION
Enabling non-blocking true before to firmware upgrade to fix the flash issue for tti and 2600 over slow speed connection.

giving sleep to  for sometime to assume that most probably firmware file has been transferred successfully
