### PR TITLE
fix(kic_script): fix eventlog vs errorqueue detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 - Fixed issue in fetching nodes for DMM6500 with no scan card installed
 - Logout is not happening for MP5000 when connection is disconnected
+- Correctly decide whether to use `eventlog` or `errorqueue` for `_KIC["error_messages"]()` in common script
 
 ### Changed
 - Removed `kic_` prefix from loaded user scripts

--- a/instrument-repl/src/resources/kic_common.tsp
+++ b/instrument-repl/src/resources/kic_common.tsp
@@ -1,85 +1,12 @@
 if not _KIC then _KIC = {} end
 
 _KIC["version"] = "!<!<VERSION>!>!"
-_KIC["TSP_VERSIONS"] = { "tti", "2600", "mp5000" }
 _KIC[".load_time_prompts"] = localnode.prompts
 
-local _2600 = 0
-local _3700 = 1
-local TTI = 2
-local MP5000 = 3
-
-local models = {
-    ["2450"] = TTI,
-    ["2470"] = TTI,
-    ["DMM7510"] = TTI,
-    ["2460"] = TTI,
-    ["2461"] = TTI,
-    ["2461-SYS"] = TTI,
-    ["DMM7512"] = TTI,
-    ["DMM6500"] = TTI,
-    ["DAQ6510"] = TTI,
-    ["2601"] = _2600,
-    ["2602"] = _2600,
-    ["2611"] = _2600,
-    ["2612"] = _2600,
-    ["2635"] = _2600,
-    ["2636"] = _2600,
-    ["2601A"] = _2600,
-    ["2602A"] = _2600,
-    ["2611A"] = _2600,
-    ["2612A"] = _2600,
-    ["2635A"] = _2600,
-    ["2636A"] = _2600,
-    ["2651A"] = _2600,
-    ["2657A"] = _2600,
-    ["2601B"] = _2600,
-    ["2601B-PULSE"] = _2600,
-    ["2602B"] = _2600,
-    ["2606B"] = _2600,
-    ["2611B"] = _2600,
-    ["2612B"] = _2600,
-    ["2635B"] = _2600,
-    ["2636B"] = _2600,
-    ["2604B"] = _2600,
-    ["2614B"] = _2600,
-    ["2634B"] = _2600,
-    ["2601B-L"] = _2600,
-    ["2602B-L"] = _2600,
-    ["2611B-L"] = _2600,
-    ["2612B-L"] = _2600,
-    ["2635B-L"] = _2600,
-    ["2636B-L"] = _2600,
-    ["2604B-L"] = _2600,
-    ["2614B-L"] = _2600,
-    ["2634B-L"] = _2600,
-    ["3706"] = _3700,
-    ["3706-SNFP"] = _3700,
-    ["3706-S"] = _3700,
-    ["3706-NFP"] = _3700,
-    ["3706A"] = _3700,
-    ["3706A-SNFP"] = _3700,
-    ["3706A-S"] = _3700,
-    ["3706A-NFP"] = _3700,
-    ["707B"] = _3700,
-    ["708B"] = _3700,
-    ["5880-SRU"] = _3700,
-    ["5881-SRU"] = _3700,
-    ["VERSATEST-600"] = MP5000,
-    ["TSPop"] = MP5000,
-    ["TSP"] = MP5000,
-    ["MP5103"] = MP5000,
-}
-
-_KIC["is_tti"] = function() return models[localnode.model] == TTI end
-_KIC["is_2600"] = function() return models[localnode.model] == _2600 end
-_KIC["is_3700"] = function() return models[localnode.model] == _3700 end
-_KIC["is_mp5000"] = function() return models[localnode.model] == MP5000 end
-
----interate over input string and escape special characters in a given string,
----making it safe for inclusion in JSON
----@param s string
----@return string
+--- Iterate over input string and escape special characters in a given string,
+--- making it safe for inclusion in JSON
+--- @param s string the string to escape
+--- @return string json_escaped_string the json-compatible, escaped string
 local function escape_str(s)
     local in_char  = { '\\', '"', '/', '\b', '\f', '\n', '\r', '\t' }
     local out_char = { '\\', '"', '/', 'b', 'f', 'n', 'r', 't' }
@@ -88,6 +15,10 @@ local function escape_str(s)
     end
     return s
 end
+
+--- Encode a lua types as JSON (where possible)
+--- @param o any The lua type to be encoded as JSON
+--- @return string json The json-string encoding the provided lua type
 _KIC["toJson"] = function(o)
     local s = ''
     if type(o) == 'table' then
@@ -119,7 +50,26 @@ _KIC["toJson"] = function(o)
     return s
 end
 
-if _KIC.is_tti() or _KIC.is_3700() then
+if errorqueue ~= nil then
+    --- Encode messages from the errorqueue in a standardized JSON and sentinel format
+    --- for TSP Toolkit to read
+    --- @return string errors The string encoding the errors
+    _KIC["error_message"] = function()
+        local errorstr = [[ERM>START]] .. "\n"
+        for _err_num = 1, errorqueue.count do
+            local error_code, message, severity, node_id = errorqueue.next()
+            errorstr = errorstr ..
+            "ERM>" ..
+            _KIC.toJson({ error_code = error_code, message = escape_str(message), severity = severity, node_id = node_id, time = nil }) ..
+            "\n"
+        end
+        errorstr = errorstr .. [[ERM>DONE]]
+        return errorstr
+    end
+elseif eventlog ~= nil then
+    --- Encode messages from the eventlog in a standardized JSON and sentinel format
+    --- for TSP Toolkit to read
+    --- @return string errors The string encoding the errors
     _KIC["error_message"] = function()
         local errorstr = [[ERM>START]] .. '\n'
         for _err_num = 1, eventlog.getcount(eventlog.SEV_ERROR) do
@@ -136,51 +86,25 @@ if _KIC.is_tti() or _KIC.is_3700() then
         errorstr = errorstr .. [[ERM>DONE]]
         return errorstr
     end
-elseif _KIC.is_2600() then
-    _KIC["error_message"] = function()
-        local errorstr = [[ERM>START]] .. "\n"
-        for _err_num = 1, errorqueue.count do
-            local error_code, message, severity, node_id = errorqueue.next()
-            errorstr = errorstr ..
-            "ERM>" ..
-            _KIC.toJson({ error_code = error_code, message = escape_str(message), severity = severity, node_id = node_id, time = nil }) ..
-            "\n"
-        end
-        errorstr = errorstr .. [[ERM>DONE]]
-        return errorstr
-    end
-elseif _KIC.is_mp5000() then
-    _KIC["error_message"] = function()
-        local errorstr = [[ERM>START]] .. "\n"
-        for _err_num = 1, errorqueue.count do
-            local error_code, message, severity, node_id = errorqueue.next()
-            errorstr = errorstr ..
-            "ERM>" ..
-            _KIC.toJson({ error_code = error_code, message = escape_str(message), severity = severity, node_id = node_id, time = nil }) ..
-            "\n"
-        end
-        errorstr = errorstr .. [[ERM>DONE]]
-        return errorstr
-    end
+
 else
-    -- Default function declarations just in case we encounter an unknown instrument
-    -- model. Anything defined here should return a string that satisfies the
-    -- caller so kic-cli can complete.
+    --- Stub implementation for if an errorqueue or eventlog are not found. This will
+    --- satisfy what TSP Toolkit is looking for so the user may continue on but will
+    --- also notify the user that we won't be able to get any error information.
+    --- @return string errors The string encoding the errors
     _KIC["error_message"] = function()
-        local errorstr = [[ERM>START]] .. "\n"
-        for _err_num = 1, errorqueue.count do
-            error_code = 0
-            severity = 0
-            node_id = 0
-            message = "Model number not recognized: '" .. localnode.model .. "'"
-            errorstr = errorstr ..
-            "ERM>" ..
-            _KIC.toJson({ error_code = error_code, message = escape_str(message), severity = severity, node_id = node_id, time = nil }) ..
-            "\n"
-        end
+        local errorstr = [[ERM>START]] .. '\n'
+        errorstr = errorstr ..
+            [[ERM>]] .. _KIC.toJson({
+                error_code = -1000,
+                message = escape_str("TSP Toolkit: No eventlog or erroqueue found on instrument. Will not be able to fetch error information."),
+                severity = 100,
+                node_id = 1,
+            }) .. "\n"
         errorstr = errorstr .. [[ERM>DONE]]
         return errorstr
     end
+
 end
 
 --- Print the given list of `fields` in the given list of `buffers` in a character delimited
@@ -236,9 +160,3 @@ _KIC["cleanup"] = function()
     _KIC = nil
 end
 
---clean up functions that aren't important after setup--
-_KIC["is_2600"] = nil
-_KIC["is_3700"] = nil
-_KIC["is_tti"] = nil
-_KIC["is_mp5000"] = nil
-_KIC["set_tsp_version"] = nil

--- a/instrument-repl/src/resources/kic_common.tsp
+++ b/instrument-repl/src/resources/kic_common.tsp
@@ -50,7 +50,7 @@ _KIC["toJson"] = function(o)
     return s
 end
 
-if errorqueue ~= nil then
+if errorqueue ~= nil and errorqueue.count ~= nil and errorqueue.next ~= nil then
     --- Encode messages from the errorqueue in a standardized JSON and sentinel format
     --- for TSP Toolkit to read
     --- @return string errors The string encoding the errors
@@ -66,7 +66,7 @@ if errorqueue ~= nil then
         errorstr = errorstr .. [[ERM>DONE]]
         return errorstr
     end
-elseif eventlog ~= nil then
+elseif eventlog ~= nil and eventlog.getcount ~= nil and eventlog.next ~= nil then
     --- Encode messages from the eventlog in a standardized JSON and sentinel format
     --- for TSP Toolkit to read
     --- @return string errors The string encoding the errors


### PR DESCRIPTION
The old logic uses the model number of the instrument to determine which to use,
`eventlog` or `errorqueue`. This is overly complicated and error-prone and has
caused numerous issues with connecting to instruments like the 3706A. Instead,
When the kic-common.tsp script is loaded we check for the existence of all the
data we need (such as `errorqueue.count()`) and we use whichever one exists
with a preference to `errorqueue`. This should be less error-prone and doesn't
require the development team to keep track of which instruments use which 
log. 

Also added a failsafe for instruments that happen to not have either so the 
instrument can connect. It will pass back an error stating that TSP errors 
cannot be returned.

Resolves: TSP-999