### PR TITLE
Fix non-UTF8 script file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Logout is not happening for MP5000 when connection is disconnected
 - Correctly decide whether to use `eventlog` or `errorqueue` for `_KIC["error_messages"]()` in common script
 - Check if each buffer passed in `.save --buffer` has any `nil` references
-<<<<<<< task/catch-script-read-errors
 - If an error occurs when reading a script file (such as non-UTF8 files like JPEGs), print the error and continue
-=======
 - Correct upgrade message based on flash target (mainframe or instrument)
->>>>>>> release/v0.21.3
+
 
 ### Changed
 - Removed `kic_` prefix from loaded user scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Logout is not happening for MP5000 when connection is disconnected
 - Correctly decide whether to use `eventlog` or `errorqueue` for `_KIC["error_messages"]()` in common script
 - Check if each buffer passed in `.save --buffer` has any `nil` references
+- If an error occurs when reading a script file (such as non-UTF8 files like JPEGs), print the error and continue
 
 ### Changed
 - Removed `kic_` prefix from loaded user scripts

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -435,8 +435,18 @@ impl Repl {
                                         format!("\nRunning Script: {}\n", file.display())
                                             .as_bytes(),
                                     )?;
-                                    (prompt, command_written) =
-                                        self.handle_script_request(&file, false, true)?;
+                                    (prompt, command_written) = match self
+                                        .handle_script_request(&file, false, true)
+                                    {
+                                        Ok((prompt, command_written)) => (prompt, command_written),
+                                        Err(e) => {
+                                            error!("unable to run script: {e}");
+                                            Self::println_error(&format!(
+                                                "Unable to run script: {e}"
+                                            ))?;
+                                            (true, true)
+                                        }
+                                    };
                                 }
                                 SaveMethod::Buffers {
                                     names,
@@ -474,7 +484,14 @@ impl Repl {
                         }
                         Request::Script { file, save, run } => {
                             (prompt, command_written) =
-                                self.handle_script_request(&file, save, run)?;
+                                match self.handle_script_request(&file, false, true) {
+                                    Ok((prompt, command_written)) => (prompt, command_written),
+                                    Err(e) => {
+                                        error!("unable to run script: {e}");
+                                        Self::println_error(&format!("Unable to run script: {e}"))?;
+                                        (true, true)
+                                    }
+                                };
                         }
                         Request::TspLinkNodes { json_file } => {
                             self.set_lang_config_path(json_file.to_string_lossy().to_string());
@@ -696,6 +713,12 @@ impl Repl {
 
     fn println_flush<D: Display>(string: &D) -> Result<()> {
         println!("{string}");
+        std::io::stdout().flush()?;
+        Ok(())
+    }
+
+    fn println_error<D: Display>(msg: &D) -> Result<()> {
+        println!("{}", msg.to_string().red());
         std::io::stdout().flush()?;
         Ok(())
     }


### PR DESCRIPTION
There was an issue where if a user would select a non-text file as a script to load, the terminal would crash. This change corrects that by catching the "non-UTF-8 file" error and gracefully recovering.

Resolves: TSP-821