### PR TITLE
Add TLS support over raw sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [0.22.0]
+
+### Added
+- TLS communication over raw sockets are now supported by default
+
 ## [0.21.5]
 
 ### Fixed
@@ -336,7 +341,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.21.5...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-cli/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.22.0
 [0.21.5]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.21.1
 [0.21.4]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.21.1
 [0.21.3]: https://github.com/tektronix/tsp-toolkit-kic-cli/releases/tag/v0.21.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +444,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -505,6 +529,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -737,6 +770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,13 +1067,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1532,6 +1589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,11 +1831,13 @@ dependencies = [
  "reqwest",
  "roxmltree",
  "rpassword",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "visa-rs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2468,6 +2537,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2650,10 +2725,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2676,6 +2753,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3647,6 +3725,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/kic-lib/Cargo.toml
+++ b/kic-lib/Cargo.toml
@@ -21,6 +21,8 @@ visa-rs = { version = "0.6.2", optional = true }
 indicatif = "0.18.4"
 roxmltree = { version = "0.20.0", default-features = false, features = ["std"] }
 keyring = { version = "3.6.2", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }
+rustls = { version = "0.23.41" }
+webpki-roots = "1.0"
 
 [features]
 visa = ["dep:visa-rs"]

--- a/kic-lib/src/error.rs
+++ b/kic-lib/src/error.rs
@@ -146,6 +146,9 @@ pub enum InstrumentError {
     #[error("authentication failure: {0}")]
     AuthenticationFailure(String),
 
+    #[error("TLS connection error: {0}")]
+    TlsError(#[from] rustls::Error),
+
     /// An uncategorized error.
     #[error("{0}")]
     Other(String),

--- a/kic-lib/src/interface/connection_addr.rs
+++ b/kic-lib/src/interface/connection_addr.rs
@@ -22,7 +22,10 @@ use crate::InstrumentError;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionInfo {
     /// A raw socket connection.
-    Lan { addr: SocketAddr },
+    Lan {
+        tls_addr: Option<SocketAddr>,
+        addr: SocketAddr,
+    },
     /// A VXI-11 connection (requires VISA to use)
     Vxi11 { string: String, addr: Ipv4Addr },
 
@@ -46,7 +49,13 @@ pub enum ConnectionInfo {
 impl Display for ConnectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Self::Lan { addr } => addr.to_string(),
+            Self::Lan { tls_addr, addr } => {
+                if let Some(tls) = tls_addr {
+                    tls.to_string()
+                } else {
+                    addr.to_string()
+                }
+            }
             Self::Vxi11 { string, .. }
             | Self::HiSlip { string, .. }
             | Self::VisaSocket { string, .. }
@@ -117,7 +126,7 @@ impl ConnectionInfo {
     pub fn get_info(&self) -> Result<InstrumentInfo, InstrumentError> {
         trace!("getting instrument info");
         let xml = match self {
-            Self::Lan { addr } if addr.ip().is_loopback() => {
+            Self::Lan { addr, .. } if addr.ip().is_loopback() => {
                 trace!("getting info over loopback");
                 //Special case for TSPop
                 let mut inst = TcpStream::connect(addr)?;
@@ -217,7 +226,7 @@ impl ConnectionInfo {
             trace!("Read {}", String::from_utf8_lossy(buf));
             match InstrumentInfo::try_from(buf) {
                 Ok(info) => return Ok(info),
-                Err(e) if iterations >= 10 => return Err(e.into()),
+                Err(e) if iterations >= 10 => return Err(e),
                 _ => {
                     iterations += 1;
                     continue;
@@ -246,7 +255,7 @@ impl ConnectionInfo {
         // number via a different route (i.e. `*IDN?` or from the resource string)
         // should return directly from the associated match arm.
         let xml = match self {
-            Self::Lan { addr } => {
+            Self::Lan { addr, .. } => {
                 // We don't know whether the instrument serves `https` or not, but if
                 // it does it will redirect, so just use `http`
                 client
@@ -306,12 +315,18 @@ fn parse_raw_socket(s: &str) -> Option<ConnectionInfo> {
     // If the user supplied an IP address has a port number on it...
     let ip = s.parse::<SocketAddr>();
     if let Ok(ip) = ip {
-        return Some(ConnectionInfo::Lan { addr: ip });
+        // TODO: check LXI ID page for `<InstrumentAddressString>`
+        return Some(ConnectionInfo::Lan {
+            addr: ip,
+            tls_addr: None,
+        });
     }
-    // If the user supplied an IP address with NO port number, default to port 5025
+    // If the user supplied an IP address with NO port number, default to port 5026 (the default TLS port)
     let ip = s.parse::<IpAddr>();
     if let Ok(ip) = ip {
+        // TODO: check LXI ID page for `<InstrumentAddressString>`
         return Some(ConnectionInfo::Lan {
+            tls_addr: Some(SocketAddr::new(ip, 5026)),
             addr: SocketAddr::new(ip, 5025),
         });
     }
@@ -497,18 +512,29 @@ pub mod unit {
             (
                 "192.168.0.1",
                 ConnectionInfo::Lan {
+                    tls_addr: Some(SocketAddr::new(
+                        IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                        5026,
+                    )),
                     addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 5025),
                 },
             ),
             (
                 "192.168.0.1:5",
                 ConnectionInfo::Lan {
+                    tls_addr: None,
                     addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 5),
                 },
             ),
             (
                 "2001:0db8:0000:0000:0000:ff00:0042:8329",
                 ConnectionInfo::Lan {
+                    tls_addr: Some(SocketAddr::new(
+                        IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
+                        )),
+                        5026,
+                    )),
                     addr: SocketAddr::new(
                         IpAddr::V6(Ipv6Addr::new(
                             0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
@@ -520,6 +546,12 @@ pub mod unit {
             (
                 "2001:db8:0:0:0:ff00:42:8329",
                 ConnectionInfo::Lan {
+                    tls_addr: Some(SocketAddr::new(
+                        IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
+                        )),
+                        5026,
+                    )),
                     addr: SocketAddr::new(
                         IpAddr::V6(Ipv6Addr::new(
                             0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
@@ -531,6 +563,12 @@ pub mod unit {
             (
                 "2001:db8::ff00:42:8329",
                 ConnectionInfo::Lan {
+                    tls_addr: Some(SocketAddr::new(
+                        IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
+                        )),
+                        5026,
+                    )),
                     addr: SocketAddr::new(
                         IpAddr::V6(Ipv6Addr::new(
                             0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,
@@ -542,6 +580,7 @@ pub mod unit {
             (
                 "[2001:db8::ff00:42:8329]:3",
                 ConnectionInfo::Lan {
+                    tls_addr: None,
                     addr: SocketAddr::new(
                         IpAddr::V6(Ipv6Addr::new(
                             0x2001, 0x0db8, 0x0, 0x0, 0x0, 0xff00, 0x0042, 0x8329,

--- a/kic-lib/src/interface/mod.rs
+++ b/kic-lib/src/interface/mod.rs
@@ -1,3 +1,5 @@
+use rustls::ClientConnection;
+
 use crate::{
     error::Result,
     instrument::{
@@ -40,3 +42,17 @@ impl Info for TcpStream {
 }
 
 impl Interface for TcpStream {}
+
+impl NonBlock for rustls::StreamOwned<ClientConnection, TcpStream> {
+    fn set_nonblocking(&mut self, enable: bool) -> Result<()> {
+        Ok(TcpStream::set_nonblocking(&self.sock, enable)?)
+    }
+}
+
+impl Info for rustls::StreamOwned<ClientConnection, TcpStream> {
+    fn info(&mut self) -> Result<InstrumentInfo> {
+        get_info(self)
+    }
+}
+
+impl Interface for rustls::StreamOwned<ClientConnection, TcpStream> {}

--- a/kic-lib/src/protocol/mod.rs
+++ b/kic-lib/src/protocol/mod.rs
@@ -4,7 +4,8 @@ use std::{
     error::Error,
     fmt::Display,
     io::{Read, Write},
-    net::TcpStream,
+    net::{SocketAddr, TcpStream},
+    sync::Arc,
     time::Duration,
 };
 
@@ -19,6 +20,11 @@ use crate::{InstrumentError, Interface};
 #[allow(unused_imports)] // ProgressState is only used in the 'visa' feature
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
+use rustls::{
+    crypto::{aws_lc_rs, verify_tls12_signature, verify_tls13_signature, CryptoProvider},
+    server::VerifierBuilderError,
+    RootCertStore,
+};
 #[allow(unused_imports)] // warn is only used in 'visa' feature
 use tracing::{debug, error, trace, warn};
 
@@ -90,6 +96,62 @@ use crate::protocol::visa::Visa;
 
 pub mod raw;
 
+/// A struct to not do any Certificate validation since the instruments create
+/// self-signed certs that don't have a known certificate authority.
+#[derive(Debug)]
+struct NoCertificateVerification(CryptoProvider);
+
+impl NoCertificateVerification {
+    fn new(provider: CryptoProvider) -> Self {
+        Self(provider)
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
 pub enum Protocol {
     Raw(Raw),
 
@@ -104,6 +166,38 @@ impl Protocol {
         Self::Raw(Raw::new(interface))
     }
 
+    #[tracing::instrument]
+    fn try_tls_lan_connection(addr: &SocketAddr) -> Result<Self, InstrumentError> {
+        trace!("Trying TLS connection");
+        let mut sock = TcpStream::connect(addr)?;
+
+        let config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification::new(
+                aws_lc_rs::default_provider(),
+            )))
+            .with_no_client_auth();
+
+        let conn = Arc::new(config);
+        let mut conn = rustls::ClientConnection::new(conn, addr.ip().into())?;
+        let (comp_read, comp_write) = conn.complete_io(&mut sock)?;
+
+        trace!("comp_read: {comp_read}, comp_write: {comp_write}");
+
+        sock.set_nonblocking(true)?;
+        sock.set_write_timeout(Some(Duration::from_millis(1000)))?;
+        sock.set_read_timeout(Some(Duration::from_millis(1000)))?;
+        Ok(Self::Raw(Raw::new(rustls::StreamOwned::new(conn, sock))))
+    }
+
+    fn try_lan_connection(addr: &SocketAddr) -> Result<Self, InstrumentError> {
+        let stream = TcpStream::connect(addr)?;
+        stream.set_nonblocking(true)?;
+        stream.set_write_timeout(Some(Duration::from_millis(1000)))?;
+        stream.set_read_timeout(Some(Duration::from_millis(1000)))?;
+        Ok(Self::Raw(Raw::new(stream)))
+    }
+
     /// Connects to the appropriate interface given a connection
     ///
     /// # Errors
@@ -112,12 +206,26 @@ impl Protocol {
     pub fn connect(info: &ConnectionInfo) -> Result<Self, InstrumentError> {
         #[allow(unused_variables)]
         match info {
-            ConnectionInfo::Lan { addr } => {
-                let stream = TcpStream::connect(addr)?;
-                stream.set_nonblocking(true)?;
-                stream.set_write_timeout(Some(Duration::from_millis(1000)))?;
-                stream.set_read_timeout(Some(Duration::from_millis(1000)))?;
-                Ok(Self::Raw(Raw::new(stream)))
+            ConnectionInfo::Lan { tls_addr, addr } => {
+                // Attempt to connect with a tls addr (normally port 5026) if available
+                if let Some(tls) = tls_addr {
+                    match Self::try_tls_lan_connection(tls) {
+                        Ok(tls_stream) => {
+                            trace!("TLS connection succeeded");
+                            Ok(tls_stream)
+                        }
+                        Err(e) => {
+                            trace!(
+                                "TLS connection failed: {e}, falling back to non-TLS connection"
+                            );
+                            // If TLS fails, use TcpStream
+                            Ok(Self::try_lan_connection(addr)?)
+                        }
+                    }
+                } else {
+                    trace!("No TLS address supplied, connecting without TLS");
+                    Ok(Self::try_lan_connection(addr)?)
+                }
             }
             ConnectionInfo::Vxi11 { string, .. }
             | ConnectionInfo::HiSlip { string, .. }

--- a/kic/src/main.rs
+++ b/kic/src/main.rs
@@ -1226,7 +1226,7 @@ fn terminate(args: &ArgMatches) -> anyhow::Result<()> {
         .into());
     };
     let mut conn = match conn {
-        ConnectionInfo::VisaSocket { addr, .. } | ConnectionInfo::Lan { addr } => {
+        ConnectionInfo::VisaSocket { addr, .. } | ConnectionInfo::Lan { addr, .. } => {
             let addr = addr.ip();
             let socket = SocketAddr::new(addr, 5030);
             TcpStream::connect(socket)?


### PR DESCRIPTION
Instrument FW will be releasing with TLS communication over raw sockets in support of EU CRA. This communication will be the preferred way to communicate with instruments and will be over port 5026 as it is encrypted. 

Resolves: TSP-1460