### PR TITLE
Normalize the CLI arguments for `terminate` to match other subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - TLS communication over raw sockets are now supported by default
 
+### Fixed
+- Normalize CLI arguments for Terminate to match the rest of the CLI args
+
 ## [0.21.5]
 
 ### Fixed

--- a/kic/src/main.rs
+++ b/kic/src/main.rs
@@ -39,23 +39,6 @@ use kic_lib::{
     ConnectionInfo,
 };
 
-#[derive(Debug, Subcommand)]
-enum TerminateType {
-    /// Perform the given action over a LAN connection.
-    Lan(LanTerminateArgs),
-}
-
-#[derive(Debug, Args)]
-struct LanTerminateArgs {
-    /// The port to which to connect in order to terminate all other connections to the
-    /// instrument
-    #[arg(long, short = 'p', default_value = "5030")]
-    port: Option<u16>,
-
-    /// The IP address of the instrument to connect to.
-    ip_addr: IpAddr,
-}
-
 // hack to make sure we rebuild if either Cargo.toml changes, since `clap` gets
 // information from there.
 #[cfg(not(debug_assertions))]
@@ -266,7 +249,7 @@ fn cmds() -> Command {
         .subcommand({
             let cmd = Command::new("terminate")
                 .about("Terminate all the connections on the given instrument. Only supports LAN.");
-            TerminateType::augment_subcommands(cmd)
+            add_connection_subcommands(cmd, [])
         })
         .subcommand({
             let cmd = Command::new("abort")


### PR DESCRIPTION
The `terminate` subcommand was using different arguments from the rest of the subcommands which meant that argument parsing and error checking wasn't working the same way. I removed the old argument types and added the typical connection arguments.

Resolves: TSP-520