### PR TITLE
Add call to visa version if applicable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "visa-rs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/kic-discover/Cargo.toml
+++ b/kic-discover/Cargo.toml
@@ -20,6 +20,7 @@ colored = { workspace = true }
 futures = "0.3.30"
 futures-util = "0.3.30"
 jsonrpsee = { workspace = true }
+kic-lib = { workspace = true, features = [] }
 lazy_static = "1.4.0"
 local-ip-address = { workspace = true }
 mdns = { workspace = true }                         # until https://github.com/dylanmckay/mdns/pull/27 is closed
@@ -32,6 +33,6 @@ thiserror = { workspace = true }
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-kic-lib = { workspace = true, features = [] }
 visa-rs = { version = "0.6.2", optional = true }
+windows-sys = { workspace = true }
 

--- a/kic-discover/src/lib.rs
+++ b/kic-discover/src/lib.rs
@@ -5,6 +5,9 @@ use kic_lib::{ki2600, model::ki3700, tti, versatest};
 pub mod ethernet;
 pub mod instrument_discovery;
 
+#[cfg(not(feature = "visa"))]
+pub mod process;
+
 #[cfg(feature = "visa")]
 pub mod visa;
 

--- a/kic-discover/src/main.rs
+++ b/kic-discover/src/main.rs
@@ -229,6 +229,7 @@ async fn main() -> anyhow::Result<()> {
 
             if let Some(kv) = kic_discover_visa_exe {
                 if kv.exists() {
+                    use anyhow::Context;
                     use kic_discover::process::Process;
 
                     Process::new(kv.clone(), std::env::args().skip(1))

--- a/kic-discover/src/main.rs
+++ b/kic-discover/src/main.rs
@@ -207,6 +207,41 @@ fn start_logger(
 #[tokio::main]
 #[instrument]
 async fn main() -> anyhow::Result<()> {
+    // automatically call into kic-discover-visa if visa is installed and kic-discover-visa exists
+    // This only needs to happen if this is NOT the VISA version.
+    #[cfg(not(feature = "visa"))]
+    {
+        let parent_dir: Option<std::path::PathBuf> = std::env::current_exe().map_or(None, |path| {
+            path.canonicalize()
+                .expect("should have canonicalized path")
+                .parent()
+                .map(std::convert::Into::into)
+        });
+
+        if kic_lib::is_visa_installed() {
+            #[cfg(target_os = "windows")]
+            let kic_discover_visa_exe: Option<std::path::PathBuf> =
+                parent_dir.clone().map(|d| d.join("kic-discover-visa.exe"));
+
+            #[cfg(target_family = "unix")]
+            let kic_discover_visa_exe: Option<std::path::PathBuf> =
+                parent_dir.clone().map(|d| d.join("kic-discover-visa"));
+
+            if let Some(kv) = kic_discover_visa_exe {
+                if kv.exists() {
+                    use kic_discover::process::Process;
+
+                    Process::new(kv.clone(), std::env::args().skip(1))
+                        .exec_replace()
+                        .context(format!(
+                            "{} should have been launched because VISA was detected",
+                            kv.display(),
+                        ))?;
+                    return Ok(());
+                }
+            }
+        }
+    }
     let cmd = command!()
         .propagate_version(true)
         .subcommand_required(true)

--- a/kic-discover/src/process.rs
+++ b/kic-discover/src/process.rs
@@ -70,7 +70,7 @@ mod imp {
 
 #[cfg(unix)]
 mod imp {
-    use crate::Process;
+    use super::Process;
     use std::os::unix::process::CommandExt;
 
     pub(super) fn exec_replace(process: &Process) -> anyhow::Result<()> {

--- a/kic-discover/src/process.rs
+++ b/kic-discover/src/process.rs
@@ -1,4 +1,3 @@
-
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -80,4 +79,3 @@ mod imp {
         Err(command.exec().into()) // Exec replaces the current application's program memory, therefore execution will
     }
 }
-

--- a/kic-discover/src/process.rs
+++ b/kic-discover/src/process.rs
@@ -1,0 +1,83 @@
+
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Process {
+    path: PathBuf,
+    args: Vec<String>,
+}
+impl Process {
+    pub fn new<I>(path: PathBuf, args: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        Self {
+            path,
+            args: args.into_iter().map(|s| s.as_ref().to_string()).collect(),
+        }
+    }
+
+    pub fn exec_replace(self) -> anyhow::Result<()> {
+        imp::exec_replace(&self)
+    }
+
+    #[cfg_attr(unix, allow(dead_code))]
+    pub fn exec(&self) -> anyhow::Result<()> {
+        let exit = std::process::Command::new(&self.path)
+            .args(&self.args)
+            .spawn()?
+            .wait()?;
+        if exit.success() {
+            Ok(())
+        } else {
+            Err(std::io::Error::other(format!(
+                "child process did not exit successfully: {}",
+                self.path.display()
+            ))
+            .into())
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+
+    use super::Process;
+    use windows_sys::Win32::{
+        Foundation::{BOOL, FALSE, TRUE},
+        System::Console::SetConsoleCtrlHandler,
+    };
+
+    #[allow(clippy::missing_const_for_fn)] // This lint seems to be broken for this specific case
+    unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
+        TRUE
+    }
+
+    pub(super) fn exec_replace(process: &Process) -> anyhow::Result<()> {
+        //Safety: This is an external handler that calls into the windows API. It is
+        //        expected to be safe.
+        unsafe {
+            if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
+                return Err(
+                    std::io::Error::other("Unable to set Ctrl+C Handler".to_string()).into(),
+                );
+            }
+        }
+
+        process.exec()
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use crate::Process;
+    use std::os::unix::process::CommandExt;
+
+    pub(super) fn exec_replace(process: &Process) -> anyhow::Result<()> {
+        let mut command = std::process::Command::new(&process.path);
+        command.args(&process.args);
+        Err(command.exec().into()) // Exec replaces the current application's program memory, therefore execution will
+    }
+}
+

--- a/kic-lib/src/protocol/mod.rs
+++ b/kic-lib/src/protocol/mod.rs
@@ -165,7 +165,7 @@ impl Protocol {
     #[tracing::instrument]
     fn try_tls_lan_connection(addr: &SocketAddr) -> Result<Self, InstrumentError> {
         trace!("Trying TLS connection");
-        let mut sock = TcpStream::connect(addr)?;
+        let mut sock = TcpStream::connect_timeout(addr, Duration::from_millis(500))?;
         sock.set_write_timeout(Some(Duration::from_millis(1000)))?;
         sock.set_read_timeout(Some(Duration::from_millis(1000)))?;
 


### PR DESCRIPTION
Fixes issues with missing VISA discovery by ensuring the VISA executable is called when appropriate.

Additionally, shorten the duration of the connection timeout when trying a TLS connection. This should resolve the long connection times.