### PR TITLE
Prepend underscore for script names starting with digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 - Cache IDN string with literal model number rather than reproducing the IDN from parsed model numbers
+- Fix 26xxA model strings
+- Honor the`.script` `--save` and `--run` flags
 
 ### Fixed
 - Normalize CLI arguments for Terminate to match the rest of the CLI args

--- a/instrument-repl/src/repl.rs
+++ b/instrument-repl/src/repl.rs
@@ -492,13 +492,9 @@ impl Repl {
                                 }
                             }
                         }
-                        Request::Script {
-                            file,
-                            save: _,
-                            run: _,
-                        } => {
+                        Request::Script { file, save, run } => {
                             (prompt, command_written) =
-                                match self.handle_script_request(&file, false, true) {
+                                match self.handle_script_request(&file, save, run) {
                                     Ok((prompt, command_written)) => (prompt, command_written),
                                     Err(e) => {
                                         error!("unable to run script: {e}");

--- a/kic-lib/src/instrument/script.rs
+++ b/kic-lib/src/instrument/script.rs
@@ -34,8 +34,18 @@ where
         save_script: bool,
         run_script: bool,
     ) -> Result<()> {
+        // The first character of a script name cannot be a number, if it is, prepend an `_` to the name
+        let name = if name[0].is_ascii_digit() {
+            let mut with_underscore = vec![b'_'];
+            with_underscore.extend(name);
+            with_underscore
+        } else {
+            name.to_vec()
+        };
         // Truncate name otherwise we risk a Fatal Error (NS-2201)
-        let name = String::from_utf8_lossy(Buf::take(name, 31).chunk()).to_string();
+        let name =
+            String::from_utf8_lossy(name.as_slice().chunks(31).next().unwrap_or(b"user_script"))
+                .to_string();
         let mut script = script.reader(); //String::from_utf8_lossy(script.as_ref()).to_string();
         self.write_all(b"_orig_prompts = localnode.prompts localnode.prompts = 0\n")?;
         self.flush()?;

--- a/kic-lib/src/model/mod.rs
+++ b/kic-lib/src/model/mod.rs
@@ -334,14 +334,14 @@ pub enum Family {
 define_models! {
     pub enum Model[InstrumentError, Family] {
         //2600
-        _2601A <- ["2601"] #Family::_26xx,
-        _2602A <- ["2602"] #Family::_26xx,
-        _2611A <- ["2611"] #Family::_26xx,
-        _2612A <- ["2612"] #Family::_26xx,
-        _2635A <- ["2635"] #Family::_26xx,
-        _2636A <- ["2636"] #Family::_26xx,
-        _2651A <- ["2651"] #Family::_26xx,
-        _2657A <- ["2657"] #Family::_26xx,
+        _2601A <- ["2601A"] #Family::_26xx,
+        _2602A <- ["2602A"] #Family::_26xx,
+        _2611A <- ["2611A"] #Family::_26xx,
+        _2612A <- ["2612A"] #Family::_26xx,
+        _2635A <- ["2635A"] #Family::_26xx,
+        _2636A <- ["2636A"] #Family::_26xx,
+        _2651A <- ["2651A"] #Family::_26xx,
+        _2657A <- ["2657A"] #Family::_26xx,
         _2601B[0x2601] <- ["2601B"] #Family::_26xx,
         _2601BPulse[0x26F1] <- ["2601B-PULSE", "2601C-PULSE"] #Family::_26xx,
         _2602B[0x2602] <- ["2602B"] #Family::_26xx,


### PR DESCRIPTION
- Ensure `save` and `run` arguments are respected
- Fix 26xxA connection strings

Resolves: TSP-1922